### PR TITLE
Don't remove focus outline CSS for keyboard accessibility

### DIFF
--- a/4-DOM-pig-game/final/style.css
+++ b/4-DOM-pig-game/final/style.css
@@ -16,8 +16,6 @@
     text-transform: uppercase;
 }
 
-.final-score:focus { outline: none; }
-
 #dice-1 { top: 120px; }
 #dice-2 { top: 250px; }
 
@@ -141,10 +139,6 @@ button {
 
 button:hover { font-weight: 600; }
 button:hover i { margin-right: 20px; }
-
-button:focus {
-    outline: none;
-}
 
 i {
     color: #EB4D4D;

--- a/4-DOM-pig-game/starter/style.css
+++ b/4-DOM-pig-game/starter/style.css
@@ -122,10 +122,6 @@ button {
 button:hover { font-weight: 600; }
 button:hover i { margin-right: 20px; }
 
-button:focus {
-    outline: none;
-}
-
 i {
     color: #EB4D4D;
     display: inline-block;

--- a/6-budgety/final/style.css
+++ b/6-budgety/final/style.css
@@ -169,11 +169,8 @@ body {
 .add__type:focus,
 .add__description:focus,
 .add__value:focus {
-    outline: none;
     border: 1px solid #28B9B5;
 }
-
-.add__btn:focus { outline: none; }
 
 /***** LISTS *****/
 .container {
@@ -258,7 +255,6 @@ h2 {
     display: none;
 }
 
-.item__delete--btn:focus { outline: none; }
 .item__delete--btn:active { transform: translateY(2px); }
 
 .item:hover .item__delete--btn { display: block; }

--- a/6-budgety/starter/style.css
+++ b/6-budgety/starter/style.css
@@ -169,11 +169,8 @@ body {
 .add__type:focus,
 .add__description:focus,
 .add__value:focus {
-    outline: none;
     border: 1px solid #28B9B5;
 }
-
-.add__btn:focus { outline: none; }
 
 /***** LISTS *****/
 .container {
@@ -258,7 +255,6 @@ h2 {
     display: none;
 }
 
-.item__delete--btn:focus { outline: none; }
 .item__delete--btn:active { transform: translateY(2px); }
 
 .item:hover .item__delete--btn { display: block; }

--- a/9-forkify/final/dist/css/style.css
+++ b/9-forkify/final/dist/css/style.css
@@ -53,8 +53,6 @@ body {
   transition: all .2s; }
   .btn:hover, .btn-small:hover {
     transform: scale(1.05); }
-  .btn:focus, .btn-small:focus {
-    outline: none; }
   .btn > *:first-child, .btn-small > *:first-child {
     margin-right: 1rem; }
 
@@ -96,8 +94,6 @@ body {
   .btn-inline:hover {
     color: #F48982;
     background-color: #F2EFEE; }
-  .btn-inline:focus {
-    outline: none; }
 
 .btn-tiny {
   height: 1.75rem;
@@ -110,8 +106,6 @@ body {
     width: 100%;
     fill: #F59A83;
     transition: all .3s; }
-  .btn-tiny:focus {
-    outline: none; }
   .btn-tiny:hover svg {
     fill: #F48982;
     transform: translateY(-1px); }
@@ -183,8 +177,6 @@ body {
     color: inherit;
     font-size: 1.7rem;
     width: 30rem; }
-    .search__field:focus {
-      outline: none; }
     .search__field::placeholder {
       color: #DAD0CC; }
 
@@ -385,8 +377,6 @@ body {
     justify-content: center; }
     .recipe__love:hover {
       transform: scale(1.07); }
-    .recipe__love:focus {
-      outline: none; }
     .recipe__love svg {
       height: 2.75rem;
       width: 2.75rem;
@@ -468,7 +458,6 @@ body {
       width: 3.7rem;
       border-radius: 3px; }
       .shopping__count input:focus {
-        outline: none;
         background-color: #F2EFEE; }
     .shopping__count p {
       font-size: 1.2rem; }

--- a/9-forkify/starter/dist/css/style.css
+++ b/9-forkify/starter/dist/css/style.css
@@ -53,8 +53,6 @@ body {
   transition: all .2s; }
   .btn:hover, .btn-small:hover {
     transform: scale(1.05); }
-  .btn:focus, .btn-small:focus {
-    outline: none; }
   .btn > *:first-child, .btn-small > *:first-child {
     margin-right: 1rem; }
 
@@ -96,8 +94,6 @@ body {
   .btn-inline:hover {
     color: #F48982;
     background-color: #F2EFEE; }
-  .btn-inline:focus {
-    outline: none; }
 
 .btn-tiny {
   height: 1.75rem;
@@ -110,8 +106,6 @@ body {
     width: 100%;
     fill: #F59A83;
     transition: all .3s; }
-  .btn-tiny:focus {
-    outline: none; }
   .btn-tiny:hover svg {
     fill: #F48982;
     transform: translateY(-1px); }
@@ -183,8 +177,6 @@ body {
     color: inherit;
     font-size: 1.7rem;
     width: 30rem; }
-    .search__field:focus {
-      outline: none; }
     .search__field::placeholder {
       color: #DAD0CC; }
 
@@ -385,8 +377,6 @@ body {
     justify-content: center; }
     .recipe__love:hover {
       transform: scale(1.07); }
-    .recipe__love:focus {
-      outline: none; }
     .recipe__love svg {
       height: 2.75rem;
       width: 2.75rem;
@@ -468,7 +458,6 @@ body {
       width: 3.7rem;
       border-radius: 3px; }
       .shopping__count input:focus {
-        outline: none;
         background-color: #F2EFEE; }
     .shopping__count p {
       font-size: 1.2rem; }


### PR DESCRIPTION
Hi! I've been enjoying your course. Thank you.

However, I noticed an issue regarding keyboard accessibility.

The outline styles for all of your buttons have been removed. This causes an issue when users have to use a keyboard to interact with your content, e.g. they don't have the motor control required for a mouse or they are using an assistive device that behaves like a keyboard.

When the focus styles are removed, they cannot detect where the keyboard focus lies. And therefore have no idea if their keyboard or device is focused on the button and whether or not they can interact with said button.

This PR removes all of the `outline: none` CSS that was present throughout this course. This will make your content more accessible for all of your users.

Thank you!