### PR TITLE
searchView - only add pagination button if button exists

### DIFF
--- a/9-forkify/final/src/js/views/searchView.js
+++ b/9-forkify/final/src/js/views/searchView.js
@@ -88,7 +88,7 @@ const renderButtons = (page, numResults, resPerPage) => {
         button = createButton(page, 'prev');
     }
 
-    elements.searchResPages.insertAdjacentHTML('afterbegin', button);
+    if (button) elements.searchResPages.insertAdjacentHTML('afterbegin', button);
 };
 
 export const renderResults = (recipes, page = 1, resPerPage = 10) => {


### PR DESCRIPTION
Button will not exist if you search for something with fewer than a page full of results 
e.g. 'Fried Yam' has only 2 recipes and instead of a button, 'undefined' is displayed