### PR TITLE
remove backdrop-filter, noticeably jittery on transition

### DIFF
--- a/07-Pig-Game/final/style.css
+++ b/07-Pig-Game/final/style.css
@@ -28,8 +28,6 @@ main {
   width: 100rem;
   height: 60rem;
   background-color: rgba(255, 255, 255, 0.35);
-  backdrop-filter: blur(200px);
-  filter: blur();
   box-shadow: 0 3rem 5rem rgba(0, 0, 0, 0.25);
   border-radius: 9px;
   overflow: hidden;
@@ -116,7 +114,6 @@ main {
 
   background-color: white;
   background-color: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(10px);
 
   padding: 0.7rem 2.5rem;
   border-radius: 50rem;

--- a/07-Pig-Game/starter/style.css
+++ b/07-Pig-Game/starter/style.css
@@ -28,8 +28,6 @@ main {
   width: 100rem;
   height: 60rem;
   background-color: rgba(255, 255, 255, 0.35);
-  backdrop-filter: blur(200px);
-  filter: blur();
   box-shadow: 0 3rem 5rem rgba(0, 0, 0, 0.25);
   border-radius: 9px;
   overflow: hidden;
@@ -116,7 +114,6 @@ main {
 
   background-color: white;
   background-color: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(10px);
 
   padding: 0.7rem 2.5rem;
   border-radius: 50rem;


### PR DESCRIPTION
On Chrome `Version 86.0.4240.111 (Official Build) (64-bit)`, when toggling the player turn on the Pig Game, the css transitions to change the background color and other properties were jittery and took longer than 0.75 seconds. The reason was `backdrop-filter`. It seems like there's no issue in Firefox, but that's because the property is ignored and has to be be enabled.

With backdrop-filter (doesn't look that bad in gif, but is more jittery in person)
![slow](https://user-images.githubusercontent.com/29286430/98287536-5942cd80-1f5a-11eb-96a9-954bc8645d63.gif)
Without backdrop-filter
![fast](https://user-images.githubusercontent.com/29286430/98287562-61027200-1f5a-11eb-9c30-f0ce953f2751.gif)

