### PR TITLE
Fixed the weird behavior of slider dots and buttons

### DIFF
--- a/13-Advanced-DOM-Bankist/final/script.js
+++ b/13-Advanced-DOM-Bankist/final/script.js
@@ -230,15 +230,16 @@ const slider = function () {
       .querySelectorAll('.dots__dot')
       .forEach(dot => dot.classList.remove('dots__dot--active'));
 
-    document
-      .querySelector(`.dots__dot[data-slide="${slide}"]`)
-      .classList.add('dots__dot--active');
+   document
+      .querySelectorAll('.dots__dot')
+      [currentSlide].classList.add('dots__dot--active');
   };
 
   const goToSlide = function (slide) {
     slides.forEach(
       (s, i) => (s.style.transform = `translateX(${100 * (i - slide)}%)`)
     );
+    activateDots();
   };
 
   // Next slide
@@ -250,7 +251,7 @@ const slider = function () {
     }
 
     goToSlide(curSlide);
-    activateDot(curSlide);
+
   };
 
   const prevSlide = function () {
@@ -260,14 +261,12 @@ const slider = function () {
       curSlide--;
     }
     goToSlide(curSlide);
-    activateDot(curSlide);
+    
   };
 
   const init = function () {
     goToSlide(0);
     createDots();
-
-    activateDot(0);
   };
   init();
 
@@ -283,8 +282,9 @@ const slider = function () {
   dotContainer.addEventListener('click', function (e) {
     if (e.target.classList.contains('dots__dot')) {
       const { slide } = e.target.dataset;
+      currentSlide = slide;
       goToSlide(slide);
-      activateDot(slide);
+      
     }
   });
 };


### PR DESCRIPTION
When we clicked on dot no. 3 and then we click right it spossed to go slide no. 1 but it goes to no. 2.
I just added current slide settings to the dot function.
```js
  dotContainer.addEventListener('click', e => {
    if (e.target.classList.contains('dots__dot')) {
      currentSlide = e.target.dataset.slide;
      goToSlides(e.target.dataset.slide);
    }
  });
```

And now you no need to active function again and  again just called one time in `goToSlides` function. Active class is set by the help of `currentSlide` variable