### PR TITLE
Update deprecated pageXOffset and pageYOffset

### DIFF
--- a/13-Advanced-DOM-Bankist/final/script.js
+++ b/13-Advanced-DOM-Bankist/final/script.js
@@ -54,13 +54,13 @@ btnScrollTo.addEventListener('click', function (e) {
 
   // Scrolling
   // window.scrollTo(
-  //   s1coords.left + window.pageXOffset,
-  //   s1coords.top + window.pageYOffset
+  //   s1coords.left + (window.scrollY || window.pageYOffSet), //pageXOffset is deprecated
+  //   s1coords.top + (window.scrollY || window.pageYOffSet) //pageYOffset is deprecated
   // );
 
   // window.scrollTo({
-  //   left: s1coords.left + window.pageXOffset,
-  //   top: s1coords.top + window.pageYOffset,
+  //   left: s1coords.left + (window.scrollX || window.pageXOffSet), //pageXOffset is deprecated
+  //   top: s1coords.top + (window.scrollY || window.pageYOffSet), //pageYOffset is deprecated
   //   behavior: 'smooth',
   // });
 


### PR DESCRIPTION
pageXOffset and pageYOffset are deprecated and have been updated to scrollX and scrollY respectively.  

scrollX & scrollY do not work in Internet Explorer and older browsers. Conditional OR maintains compatibility in both modern and older browsers.